### PR TITLE
Rename charm config options to match the spec

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,25 +1,25 @@
 options:
-  cidr:
-    type: string
-    default: "192.168.0.0/16"
-    description: |
-      Pod CIDR
-  gateway:
-    type: string
-    default: "192.168.0.1"
-    description: |
-      Default gateway in the Pod network
-  label:
+  control-plane-node-label:
     type: string
     default: "juju-application=kubernetes-control-plane"
     description: |
-      Node label for selecting nodes to host the OVN control plane.
-  pinger-address:
+      Node label for selecting nodes to host the Kube-OVN control plane.
+  default-cidr:
+    type: string
+    default: "192.168.0.0/16"
+    description: |
+      Default pod CIDR
+  default-gateway:
+    type: string
+    default: "192.168.0.1"
+    description: |
+      Default gateway for the pod network
+  pinger-external-address:
     type: string
     default: "114.114.114.114"
     description: |
       External IP address used by kube-ovn-pinger for connectivity testing.
-  pinger-dns:
+  pinger-external-dns:
     type: string
     default: "alauda.cn"
     description: |

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,11 +34,11 @@ class KubeOvnCharm(CharmBase):
     def apply_kube_ovn(self):
         self.unit.status = MaintenanceStatus("Applying Kube-OVN resources")
         resources = self.load_manifest("kube-ovn.yaml")
-        cidr = self.model.config["cidr"]
-        gateway = self.model.config["gateway"]
+        cidr = self.model.config["default-cidr"]
+        gateway = self.model.config["default-gateway"]
         service_cidr = self.model.config["service-cidr"]
-        pinger_address = self.model.config["pinger-address"]
-        pinger_dns = self.model.config["pinger-dns"]
+        pinger_address = self.model.config["pinger-external-address"]
+        pinger_dns = self.model.config["pinger-external-dns"]
         node_ips = self.get_ovn_node_ips()
 
         self.replace_images(resources)
@@ -133,7 +133,7 @@ class KubeOvnCharm(CharmBase):
 
     def configure_cni_relation(self):
         self.unit.status = MaintenanceStatus("Configuring CNI relation")
-        cidr = self.model.config["cidr"]
+        cidr = self.model.config["default-cidr"]
         for relation in self.model.relations["cni"]:
             relation.data[self.unit]["cidr"] = cidr
             relation.data[self.unit]["cni-conf-file"] = "01-kube-ovn.yaml"
@@ -163,7 +163,7 @@ class KubeOvnCharm(CharmBase):
         return container
 
     def get_ovn_node_ips(self):
-        label = self.model.config["label"]
+        label = self.model.config["control-plane-node-label"]
 
         nodes = json.loads(self.kubectl("get", "node", "-l", label, "-o", "json"))[
             "items"
@@ -275,7 +275,7 @@ class KubeOvnCharm(CharmBase):
                         )
 
     def replace_node_selector(self, resource):
-        label = self.model.config["label"]
+        label = self.model.config["control-plane-node-label"]
         label_key, label_value = label.split("=")
 
         node_selector = resource["spec"]["template"]["spec"]["nodeSelector"]


### PR DESCRIPTION
The config option names in the PoC were pretty basic. The names in the spec were thought through more carefully and should be clearer. Let's use them.