### PR TITLE
Use service-cidr from the cni relation rather than charm config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,8 +29,3 @@ options:
     default: "rocks.canonical.com"
     description: |
       Image registry for the kube-ovn image.
-  service-cidr:
-    type: string
-    default: "10.152.183.0/24"
-    description: |
-      Service CIDR. This must match the service-cidr config of kubernetes-control-plane.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,6 +8,9 @@ requires:
   cni:
     interface: kubernetes-cni
     scope: container
+peers:
+  kube-ovn:
+    interface: kube-ovn
 resources:
   kubectl-ko:
     type: file

--- a/src/charm.py
+++ b/src/charm.py
@@ -249,8 +249,7 @@ class KubeOvnCharm(CharmBase):
         cni_service_cidr = event.relation.data[event.unit].get("service-cidr")
         if cni_service_cidr:
             for relation in self.model.relations["kube-ovn"]:
-                for unit in relation.units | {self.unit}:
-                    relation.data[unit]["service-cidr"] = cni_service_cidr
+                relation.data[self.unit]["service-cidr"] = cni_service_cidr
 
     def get_service_cidr(self):
         """Return the agreed service-cidr from each kube-ovn unit including self.

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,6 +35,9 @@ class KubeOvnCharm(CharmBase):
             self.on.cni_relation_changed, self.on_cni_relation_changed
         )
         self.framework.observe(self.on.cni_relation_joined, self.on_cni_relation_joined)
+        self.framework.observe(
+            self.on.kube_ovn_relation_changed, self.on_kube_ovn_relation_changed
+        )
         self.framework.observe(self.on.config_changed, self.on_config_changed)
         self.framework.observe(self.on.install, self.on_install)
         self.framework.observe(self.on.remove, self.on_remove)
@@ -236,14 +239,27 @@ class KubeOvnCharm(CharmBase):
                     return True
         return False
 
+    def set_service_cidr(self, event):
+        """Repeat received service-cidr from k8s-cp to each kube-ovn unit.
+
+        service-cidr is received over the cni relation only from
+        kubernetes-control-plane units.  the kube-ovn peer relation
+        shares the value around to each kube-ovn unit.
+        """
+        cni_service_cidr = event.relation.data[event.unit].get("service-cidr")
+        if cni_service_cidr:
+            for relation in self.model.relations["kube-ovn"]:
+                for unit in relation.units | {self.unit}:
+                    relation.data[unit]["service-cidr"] = cni_service_cidr
+
     def get_service_cidr(self):
-        """Return the agreed service-cidr from each related cni unit.
+        """Return the agreed service-cidr from each kube-ovn unit including self.
 
         If there isn't unity in the relation, return None
         """
         joined_service_cidr = set()
-        for relation in self.model.relations["cni"]:
-            for unit in relation.units:
+        for relation in self.model.relations["kube-ovn"]:
+            for unit in relation.units | {self.unit}:
                 service_cidr = relation.data[unit].get("service-cidr")
                 joined_service_cidr.add(service_cidr)
         filtered = set(filter(bool, joined_service_cidr))
@@ -262,6 +278,15 @@ class KubeOvnCharm(CharmBase):
         self.set_active_status()
 
     def on_cni_relation_changed(self, event):
+        self.set_service_cidr(event)
+
+        if not self.configure_kube_ovn():
+            self.schedule_event_retry(event, "Waiting to retry configuring Kube-OVN")
+            return
+
+        self.set_active_status()
+
+    def on_kube_ovn_relation_changed(self, event):
         if not self.configure_kube_ovn():
             self.schedule_event_retry(event, "Waiting to retry configuring Kube-OVN")
             return


### PR DESCRIPTION
Using the newly added `service-cidr` data from the cni relation.  

In the relation `service-cidr` is a comma-separated list of cidrs (v4 and v6)

These PRs are also required
* https://github.com/juju-solutions/interface-kubernetes-cni/pull/11
* https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/230