### PR TITLE
Update integration workflow to capture crashdump on timeout

### DIFF
--- a/.github/workflows/vsphere-integration.yml
+++ b/.github/workflows/vsphere-integration.yml
@@ -23,7 +23,6 @@ jobs:
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
       - name: Run test
         run: tox -e integration
-        timeout-minutes: 60
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp

--- a/.github/workflows/vsphere-integration.yml
+++ b/.github/workflows/vsphere-integration.yml
@@ -5,7 +5,7 @@ jobs:
   integration-test:
     name: VSphere Integration Test
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -23,6 +23,7 @@ jobs:
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
       - name: Run test
         run: tox -e integration
+        timeout-minutes: 60
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp


### PR DESCRIPTION
The workflow template was updated here: https://github.com/charmed-kubernetes/.github/pull/2

Just bringing the update in to this repo.