### PR TITLE
Fix excessively long waits during hooks

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -41,6 +41,7 @@ class KubeOvnCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self.on_config_changed)
         self.framework.observe(self.on.install, self.on_install)
         self.framework.observe(self.on.remove, self.on_remove)
+        self.framework.observe(self.on.update_status, self.on_update_status)
         self.framework.observe(self.on.upgrade_charm, self.on_upgrade_charm)
 
     def add_container_args(self, container, args, command=False):
@@ -115,8 +116,6 @@ class KubeOvnCharm(CharmBase):
         self.set_replicas(kube_ovn_monitor, len(node_ips))
 
         self.apply_manifest(resources, "kube-ovn.yaml")
-        self.wait_for_kube_ovn_controller()
-        self.wait_for_kube_ovn_cni()
 
     def apply_manifest(self, manifest, name):
         destination = self.render_manifest(manifest, name)
@@ -143,7 +142,6 @@ class KubeOvnCharm(CharmBase):
         )
 
         self.apply_manifest(resources, "ovn.yaml")
-        self.wait_for_ovn_central()
 
     def check_if_pod_restart_will_be_needed(self):
         output = self.kubectl(
@@ -167,11 +165,13 @@ class KubeOvnCharm(CharmBase):
             relation.data[self.unit]["cidr"] = cidr
             relation.data[self.unit]["cni-conf-file"] = "01-kube-ovn.conflist"
 
-    def configure_kube_ovn(self) -> bool:
+    def configure_kube_ovn(self):
+        self.stored.kube_ovn_configured = False
+
         service_cidr = self.get_service_cidr()
         if not self.is_kubeconfig_available() or not service_cidr:
             self.unit.status = WaitingStatus("Waiting for CNI relation")
-            return False
+            return
 
         try:
             self.check_if_pod_restart_will_be_needed()
@@ -181,15 +181,18 @@ class KubeOvnCharm(CharmBase):
             self.apply_kube_ovn(service_cidr)
 
             if self.stored.pod_restart_needed:
+                self.wait_for_ovn_central()
+                self.wait_for_kube_ovn_controller()
+                self.wait_for_kube_ovn_cni()
                 self.restart_pods()
         except CalledProcessError:
             # Likely the Kubernetes API is unavailable. Log the exception in
             # case it it something else, and let the caller know we failed.
             log.error(traceback.format_exc())
-            return False
+            self.unit.status = WaitingStatus("Waiting to retry configuring Kube-OVN")
+            return
 
         self.stored.kube_ovn_configured = True
-        return True
 
     def get_charm_resource_path(self, resource_name):
         try:
@@ -292,27 +295,16 @@ class KubeOvnCharm(CharmBase):
 
     def on_cni_relation_changed(self, event):
         self.set_service_cidr(event)
-
-        if not self.configure_kube_ovn():
-            self.schedule_event_retry(event, "Waiting to retry configuring Kube-OVN")
-            return
-
+        self.configure_kube_ovn()
         self.set_active_status()
 
     def on_kube_ovn_relation_changed(self, event):
-        if not self.configure_kube_ovn():
-            self.schedule_event_retry(event, "Waiting to retry configuring Kube-OVN")
-            return
-
+        self.configure_kube_ovn()
         self.set_active_status()
 
     def on_config_changed(self, event):
         self.configure_cni_relation()
-
-        if not self.configure_kube_ovn():
-            self.schedule_event_retry(event, "Waiting to retry configuring Kube-OVN")
-            return
-
+        self.configure_kube_ovn()
         self.set_active_status()
 
     def on_install(self, _):
@@ -320,6 +312,11 @@ class KubeOvnCharm(CharmBase):
 
     def on_remove(self, _):
         self.remove_kubectl_plugin("kubectl-ko")
+
+    def on_update_status(self, _):
+        if not self.stored.kube_ovn_configured:
+            self.configure_kube_ovn()
+        self.set_active_status()
 
     def on_upgrade_charm(self, _):
         self.install_kubectl_plugin("kubectl-ko")
@@ -411,10 +408,6 @@ class KubeOvnCharm(CharmBase):
                 self.kubectl("delete", "po", "-n", namespace, pod, "--ignore-not-found")
         self.stored.pod_restart_needed = False
 
-    def schedule_event_retry(self, event, message):
-        self.unit.status = WaitingStatus(message)
-        event.defer()
-
     def set_active_status(self):
         if self.stored.kube_ovn_configured:
             self.unit.status = ActiveStatus()
@@ -434,7 +427,7 @@ class KubeOvnCharm(CharmBase):
         self.unit.status = WaitingStatus("Waiting for ovn-central")
         self.wait_for_rollout("deployment/ovn-central")
 
-    def wait_for_rollout(self, name, namespace="kube-system", timeout=300):
+    def wait_for_rollout(self, name, namespace="kube-system", timeout=1):
         self.kubectl(
             "rollout", "status", "-n", namespace, name, "--timeout", str(timeout) + "s"
         )


### PR DESCRIPTION
Fix excessive waits in the kube-ovn charm that block kubernetes-control-plane from configuring kubelet.

The overall goal here is to make it so that the kube-ovn charm can effectively wait for the kube-ovn pods to come up as needed, without holding a machine lock that prevents kubernetes-control-plane from processing hooks.

There are three parts to this:

1. Reduce the `wait_for_rollout` timeout from `300s` to `1s`. This will allow us to release the machine lock a lot sooner. We can expect that the first `wait_for_rollout` call is likely to fail quickly, but it's not a huge problem; the charm will retry on a future hook, within 5 minutes.

2. Delay calling `wait_for_rollout` until after all of the kube-ovn manifests have been applied. We want to get all the pods coming up as soon as we can, without waiting between every step.

3. Don't use `event.defer()`. The event deferral pattern can lead to a dangerous buildup of re-emitting events. I saw a single `cni-relation-changed` hook take over 30 minutes because it re-emitted 1 `config_changed` event and 3 `cni_relation_changed`. That's 4 calls to `configure_kube_ovn` in a single hook invocation. We don't want that. Instead, add an `update_status` event listener that will retry `configure_kube_ovn` if needed.