### PR TITLE
Add tests for gateway QoS

### DIFF
--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -10,6 +10,9 @@ applications:
     charm: {{charm}}
     resources:
       kubectl-ko: {{plugin}}
+  ubuntu:
+    charm: ubuntu
+    num_units: 1
 relations:
 - - kube-ovn:cni
   - kubernetes-control-plane:cni

--- a/tests/data/gateway_qos.yaml
+++ b/tests/data/gateway_qos.yaml
@@ -1,0 +1,34 @@
+apiVersion: kubeovn.io/v1
+kind: Subnet
+metadata:
+  name: centralized
+spec:
+  protocol: IPv4
+  cidrBlock: 10.166.0.0/16
+  default: false
+  excludeIps:
+  - 10.166.0.1
+  gateway: 10.166.0.1
+  gatewayType: centralized
+  gatewayNode: "a-node"
+  natOutgoing: true
+  namespaces:
+  - centralized-ns
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: centralized-ns
+---
+# used for running an iperf3 client manually using kubectl exec
+apiVersion: v1
+kind: Pod
+metadata:
+  name: perf-client
+  namespace: centralized-ns
+  labels:
+    app.kubernetes.io/name: perf-client
+spec:
+  containers:
+  - name: perf-client
+    image: rocks.canonical.com/cdk/kubeovn/perf:latest

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,11 +4,14 @@ import pytest
 import logging
 
 from pathlib import Path
+import yaml
+import shlex
 from lightkube import Client, codecs, KubeConfig
 from lightkube.resources.apps_v1 import DaemonSet
 from lightkube.resources.core_v1 import Pod
 from lightkube.resources.core_v1 import Namespace
-
+from lightkube.resources.core_v1 import Node
+from lightkube.generic_resource import create_global_resource
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +42,71 @@ async def client(kubeconfig):
         trust_env=False,
     )
     yield client
+
+
+@pytest.fixture(scope="module")
+def subnet_resource(client):
+    return create_global_resource("kubeovn.io", "v1", "Subnet", "subnets")
+
+
+@pytest.fixture(scope="module")
+def worker_node(client):
+    # Returns a worker node
+    for node in client.list(Node):
+        if node.metadata.labels["juju-application"] == "kubernetes-worker":
+            return node
+
+
+@pytest.fixture(scope="module")
+async def gateway_server(ops_test):
+    cmd = "juju run --unit ubuntu/0 -- sudo apt install -y iperf3"
+    rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
+    assert rc == 0, f"Failed to install iperf3: {(stdout or stderr).strip()}"
+
+    iperf3_cmd = "iperf3 -s --daemon"
+    cmd = f"juju run --unit ubuntu/0 -- {iperf3_cmd}"
+    rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
+    assert rc == 0, f"Failed to run iperf3 server: {(stdout or stderr).strip()}"
+
+    cmd = "juju show-unit ubuntu/0"
+    rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
+    assert rc == 0, f"Failed to get ubuntu/0 unit data: {(stdout or stderr).strip()}"
+
+    unit_data = yaml.safe_load(stdout)
+    return unit_data["ubuntu/0"]["public-address"]
+
+
+@pytest.fixture()
+def gateway_client_pod(client, worker_node, subnet_resource):
+    log.info("Creating gateway QoS-related resources ...")
+    path = Path.cwd() / "tests/data/gateway_qos.yaml"
+    with open(path) as f:
+        for obj in codecs.load_all_yaml(f):
+            if obj.kind == "Subnet":
+                obj.spec["gatewayNode"] = worker_node.metadata.name
+            if obj.kind == "Namespace":
+                namespace = obj.metadata.name
+            if obj.kind == "Pod":
+                pod_name = obj.metadata.name
+            client.create(obj)
+
+    client_pod = client.get(Pod, name=pod_name, namespace=namespace)
+    # wait for pod to come up
+    client.wait(
+        Pod,
+        client_pod.metadata.name,
+        for_conditions=["Ready"],
+        namespace=namespace,
+    )
+
+    yield client_pod
+
+    log.info("Deleting gateway QoS-related resources ...")
+    with open(path) as f:
+        for obj in codecs.load_all_yaml(f):
+            client.delete(
+                type(obj), obj.metadata.name, namespace=obj.metadata.namespace
+            )
 
 
 @pytest.fixture()

--- a/tests/integration/test_kube_ovn.py
+++ b/tests/integration/test_kube_ovn.py
@@ -64,10 +64,11 @@ async def test_pod_network_limits(ops_test, kubeconfig, client, iperf3_pods):
     server, test_pod, _ = iperf3_pods
     namespace = server.metadata.namespace
 
-    rate_values = (
-        'ovn.kubernetes.io/ingress_rate="10" ovn.kubernetes.io/egress_rate="5"'
-    )
-    await annotate_pod(ops_test, kubeconfig, test_pod, namespace, rate_values)
+    rate_values = {
+        "ovn.kubernetes.io/ingress_rate": "10",
+        "ovn.kubernetes.io/egress_rate": "5",
+    }
+    await annotate_obj(client, test_pod, rate_values)
 
     log.info("Test ingress bandwidth...")
     ingress_bw = await run_bandwidth_test(
@@ -77,7 +78,7 @@ async def test_pod_network_limits(ops_test, kubeconfig, client, iperf3_pods):
 
     log.info("Test egress bandwidth...")
     egress_bw = await run_bandwidth_test(
-        ops_test, test_pod, server, namespace, kubeconfig
+        ops_test, server, test_pod, namespace, kubeconfig, reverse=True
     )
     assert isclose(egress_bw, 10.0, abs_tol=0.5)
 
@@ -104,15 +105,11 @@ async def test_linux_htb_performance(ops_test, kubeconfig, client, iperf3_pods):
 
     assert rc == 0, f"Failed to setup iperf3 servers: {(stderr or stdout).strip()}"
 
-    new_priority_annotation = f'ovn.kubernetes.io/priority="{NEW_PRIORITY_HTB}"'
-    await annotate_pod(
-        ops_test, kubeconfig, pod_prior, namespace, new_priority_annotation
-    )
+    new_priority_annotation = {"ovn.kubernetes.io/priority": f"{NEW_PRIORITY_HTB}"}
+    await annotate_obj(client, pod_prior, new_priority_annotation)
 
-    low_priority_annotation = f'ovn.kubernetes.io/priority="{LOW_PRIORITY_HTB}"'
-    await annotate_pod(
-        ops_test, kubeconfig, pod_non_prior, namespace, low_priority_annotation
-    )
+    low_priority_annotation = {"ovn.kubernetes.io/priority": f"{LOW_PRIORITY_HTB}"}
+    await annotate_obj(client, pod_non_prior, low_priority_annotation)
 
     cmd = []
     cmd.append(
@@ -156,8 +153,8 @@ async def test_pod_netem_latency(ops_test, kubeconfig, client, iperf3_pods):
 
     # latency is in ms
     latency = 1000
-    latency_annotation = f'ovn.kubernetes.io/latency="{latency}"'
-    await annotate_pod(ops_test, kubeconfig, pinger, namespace, latency_annotation)
+    latency_annotation = {"ovn.kubernetes.io/latency": f"{latency}"}
+    await annotate_obj(client, pinger, latency_annotation)
 
     log.info("Testing ping latency ...")
     stdout = await ping(ops_test, pinger, pingee, namespace, kubeconfig)
@@ -177,8 +174,8 @@ async def test_pod_netem_loss(ops_test, kubeconfig, client, iperf3_pods):
 
     # Annotate and test again
     expected_loss = 100
-    loss_annotation = f'ovn.kubernetes.io/loss="{expected_loss}"'
-    await annotate_pod(ops_test, kubeconfig, pinger, namespace, loss_annotation)
+    loss_annotation = {"ovn.kubernetes.io/loss": f"{expected_loss}"}
+    await annotate_obj(client, pinger, loss_annotation)
 
     log.info("Testing ping loss ...")
     stdout = await ping(ops_test, pinger, pingee, namespace, kubeconfig)
@@ -191,10 +188,8 @@ async def test_pod_netem_limit(ops_test, kubeconfig, client, iperf3_pods):
     for pod in iperf3_pods:
         # Annotate all the pods so we dont have to worry about
         # which worker node we pick to check the qdisk
-        limit_annotation = f'ovn.kubernetes.io/limit="{expected_limit}"'
-        await annotate_pod(
-            ops_test, kubeconfig, pod, pod.metadata.namespace, limit_annotation
-        )
+        limit_annotation = {"ovn.kubernetes.io/limit": f"{expected_limit}"}
+        await annotate_obj(client, pod, limit_annotation)
 
     log.info("Looking for kubernetes-worker/0 netem interface ...")
     cmd = "juju run --unit kubernetes-worker/0 -- ip link"
@@ -210,6 +205,36 @@ async def test_pod_netem_limit(ops_test, kubeconfig, client, iperf3_pods):
     assert actual_limit == expected_limit
 
 
+async def test_gateway_qos(
+    ops_test, kubeconfig, client, gateway_server, gateway_client_pod, worker_node
+):
+    namespace = gateway_client_pod.metadata.namespace
+
+    rate_annotations = {
+        "ovn.kubernetes.io/ingress_rate": "60",
+        "ovn.kubernetes.io/egress_rate": "30",
+    }
+
+    await annotate_obj(client, worker_node, rate_annotations)
+
+    log.info("Testing node-level ingress bandwidth...")
+    ingress_bw = await run_external_bandwidth_test(
+        ops_test,
+        gateway_server,
+        gateway_client_pod,
+        namespace,
+        kubeconfig,
+        reverse=True,
+    )
+    assert isclose(ingress_bw, 60, rel_tol=0.10)
+
+    log.info("Testing node-level egress bandwidth...")
+    egress_bw = await run_external_bandwidth_test(
+        ops_test, gateway_server, gateway_client_pod, namespace, kubeconfig
+    )
+    assert isclose(egress_bw, 30.0, rel_tol=0.10)
+
+
 def parse_iperf_result(output):
     # First line contains test result
     line = output.split("\n")[0]
@@ -217,7 +242,9 @@ def parse_iperf_result(output):
     return float(re.sub(" +", " ", line).split(" ")[6])
 
 
-async def run_bandwidth_test(ops_test, server, client, namespace, kubeconfig):
+async def run_bandwidth_test(
+    ops_test, server, client, namespace, kubeconfig, reverse=False
+):
     server_ip = server.status.podIP
 
     log.info("Setup iperf3 server...")
@@ -230,12 +257,28 @@ async def run_bandwidth_test(ops_test, server, client, namespace, kubeconfig):
     rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
 
     assert rc == 0, f"Failed to setup iperf3 server: {(stderr or stdout).strip()}"
-
+    reverse_flag = "-R" if reverse else ""
     cmd = (
         f"kubectl --kubeconfig {kubeconfig} "
         f"exec {client.metadata.name} "
         f"-n {namespace} "
-        f'-- sh -c "iperf3 -c {server_ip} -p 5101 | tail -3"'
+        f'-- sh -c "iperf3 -c {server_ip} {reverse_flag} -p 5101 | tail -3"'
+    )
+    rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
+    assert rc == 0, f"Failed to run iperf3 test: {(stdout or stderr).strip()}"
+
+    return parse_iperf_result(stdout)
+
+
+async def run_external_bandwidth_test(
+    ops_test, server, client, namespace, kubeconfig, reverse=False
+):
+    reverse_flag = "-R" if reverse else ""
+    cmd = (
+        f"kubectl --kubeconfig {kubeconfig} "
+        f"exec {client.metadata.name} "
+        f"-n {namespace} "
+        f'-- sh -c "iperf3 -c {server} {reverse_flag} | tail -3"'
     )
     rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
     assert rc == 0, f"Failed to run iperf3 test: {(stdout or stderr).strip()}"
@@ -315,14 +358,9 @@ def parse_tc_show(stdout):
     return int(limit_value)
 
 
-async def annotate_pod(ops_test, kubeconfig, pod, namespace, annotation):
-    log.info(f"Annotating pod {pod.metadata.name} with {annotation} ...")
-    cmd = (
-        f"kubectl --kubeconfig {kubeconfig} "
-        "annotate --overwrite "
-        f"pod {pod.metadata.name} "
-        f"-n {namespace} {annotation}"
+async def annotate_obj(client, obj, annotation_dict):
+    log.info(f"Annotating {type(obj)} {obj.metadata.name} with {annotation_dict} ...")
+    obj.metadata.annotations = annotation_dict
+    client.patch(
+        type(obj), obj.metadata.name, obj, namespace=obj.metadata.namespace, force=True
     )
-    rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
-
-    assert rc == 0, f"Failed to annotate pod: {(stdout or stderr).strip()}"


### PR DESCRIPTION
This PR adds tests for the gateway QoS annotations described [here](https://github.com/kubeovn/kube-ovn/blob/master/docs/qos.md#gateway-qos). Additionally it refactors some of the previous tests to use a new lightkube-based annotation method. 