### PR TITLE
Remove PSP from ovn.yaml

### DIFF
--- a/templates/ovn.yaml
+++ b/templates/ovn.yaml
@@ -2,6 +2,7 @@
 # upstream manifest as possible.
 #
 # N.B There is not a 1.25 release yet so using master branch yaml
+# The master branch version uses 1.10.0 as its ovn images, and these have been modified to 1.10.4
 # https://raw.githubusercontent.com/kubeovn/kube-ovn/master/yamls/ovn.yaml
 
 apiVersion: v1
@@ -235,7 +236,7 @@ spec:
       hostNetwork: true
       containers:
         - name: ovn-central
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.10.4"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-db.sh"]
           securityContext:
@@ -368,7 +369,7 @@ spec:
       hostPID: true
       containers:
         - name: openvswitch
-          image: "kubeovn/kube-ovn:v1.10.0"
+          image: "kubeovn/kube-ovn:v1.10.4"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-ovs.sh"]
           securityContext:

--- a/templates/ovn.yaml
+++ b/templates/ovn.yaml
@@ -1,46 +1,9 @@
 # DO NOT EDIT - For maintainability, we should keep this as close to the
 # upstream manifest as possible.
 #
-# https://raw.githubusercontent.com/kubeovn/kube-ovn/v1.10.4/yamls/ovn.yaml
+# N.B There is not a 1.25 release yet so using master branch yaml
+# https://raw.githubusercontent.com/kubeovn/kube-ovn/master/yamls/ovn.yaml
 
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: kube-ovn
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-spec:
-  privileged: true
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-    - '*'
-  volumes:
-    - '*'
-  hostNetwork: true
-  hostPorts:
-    - min: 0
-      max: 65535
-  hostIPC: true
-  hostPID: true
-  runAsUser:
-    rule: 'RunAsAny'
-  seLinux:
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'RunAsAny'
-  fsGroup:
-    rule: 'RunAsAny'
-
----
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ovn-config
-  namespace: kube-system
-data:
-  defaultNetworkType: geneve
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -54,11 +17,6 @@ metadata:
     rbac.authorization.k8s.io/system-only: "true"
   name: system:ovn
 rules:
-  - apiGroups: ['policy']
-    resources: ['podsecuritypolicies']
-    verbs:     ['use']
-    resourceNames:
-      - kube-ovn
   - apiGroups:
       - "kubeovn.io"
     resources:
@@ -85,6 +43,8 @@ rules:
       - iptables-fip-rules/status
       - iptables-dnat-rules/status
       - iptables-snat-rules/status
+      - switch-lb-rules
+      - switch-lb-rules/status
     verbs:
       - "*"
   - apiGroups:
@@ -120,6 +80,7 @@ rules:
     resources:
       - networkpolicies
       - services
+      - services/status
       - endpoints
       - statefulsets
       - daemonsets
@@ -141,6 +102,12 @@ rules:
       - create
       - patch
       - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - "*"
   - apiGroups:
       - "k8s.cni.cncf.io"
     resources:
@@ -268,7 +235,7 @@ spec:
       hostNetwork: true
       containers:
         - name: ovn-central
-          image: "kubeovn/kube-ovn:v1.10.4"
+          image: "kubeovn/kube-ovn:v1.10.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-db.sh"]
           securityContext:
@@ -395,13 +362,13 @@ spec:
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       serviceAccountName: ovn
       hostNetwork: true
       hostPID: true
       containers:
         - name: openvswitch
-          image: "kubeovn/kube-ovn:v1.10.4"
+          image: "kubeovn/kube-ovn:v1.10.0"
           imagePullPolicy: IfNotPresent
           command: ["/kube-ovn/start-ovs.sh"]
           securityContext:

--- a/tests/data/vsphere-overlay.yaml
+++ b/tests/data/vsphere-overlay.yaml
@@ -11,7 +11,7 @@ applications:
     trust: true
     options:
       datastore: vsanDatastore
-      folder: k8s-crew-root
+      folder: k8s-ci-root
 relations:
   - ['vsphere-integrator', 'kubernetes-control-plane']
   - ['vsphere-integrator', 'kubernetes-worker']

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -396,7 +396,7 @@ async def grafana_password(ops_test, related_grafana, k8s_model, grafana_app):
             .run_action("get-admin-password")
         )
         action = await action.wait()
-    return action["admin-password"]
+    return action.results["admin-password"]
 
 
 @pytest_asyncio.fixture(scope="module")

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
 
 [testenv:integration]
 deps =
-    juju == 3.0.0
+    git+https://github.com/charmed-kubernetes/python-libjuju.git@2.9.11+ck1
     aiohttp
     urllib3
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
 
 [testenv:integration]
 deps =
-    juju == 2.9.10
+    juju == 3.0.0
     aiohttp
     urllib3
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands =
 
 [testenv:integration]
 deps =
+    juju == 2.9.10
     aiohttp
     urllib3
     pytest


### PR DESCRIPTION
The PSP has been removed from ovn.yaml to accommodate 1.25.

[Upstream PR](https://github.com/kubeovn/kube-ovn/pull/1822).

Failing integration tests require the following PRs be merged and the updated control plane charm in available in charmhub edge channels:
https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/31
https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/242