### PR TITLE
Change node-{cidr,gateway} config warnings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,12 +23,14 @@ options:
     type: string
     default: "100.64.0.0/16"
     description: |
-      CIDR for node switch (This value cannot be changed after deployment).
+      CIDR for node switch (This value requires additional steps/procedures to be changed. Refer to 
+      the charm docs for more information).
   node-switch-gateway:
     type: string
     default: "100.64.0.1"
     description: |
-      Gateway for node switch (This value cannot be changed after deployment).
+      Gateway for node switch (This value requires additional steps/procedures to be changed. Refer to 
+      the charm docs for more information).
   pinger-external-address:
     type: string
     default: "8.8.8.8"


### PR DESCRIPTION
## Changes
There's now a procedure to change node's CIDR and gateway after charm has been deployed. [Docs PR](https://github.com/charmed-kubernetes/kubernetes-docs/pull/713/files).
This PR changes the configuration descriptions to ones more in line with the current state.