### PR TITLE
Add BGP support/tests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ options:
         neighbor-as: 65030
         cluster-as: 65000
         announce-cluster-ip: true
-        v: 2
+        log-level: 2
   control-plane-node-label:
     type: string
     default: "juju-application=kubernetes-control-plane"

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,17 @@
 options:
+  bgp-speakers:
+    type: string
+    default: ""
+    description: |
+      YAML defining a list of speaker configurations. Multiple speakers can be defined as separate list entries
+      Example:
+      - name: my-speaker
+        node-selector: juju-application=kubernetes-worker
+        neighbor-address: 10.32.32.1
+        neighbor-as: 65030
+        cluster-as: 65000
+        announce-cluster-ip: true
+        v: 2
   control-plane-node-label:
     type: string
     default: "juju-application=kubernetes-control-plane"
@@ -19,6 +32,11 @@ options:
     default: "kube-ovn-grafana-agent"
     description: |
       Default namespace for the grafana agent deployment (This value cannot be changed after deployment).
+  image-registry:
+    type: string
+    default: ""
+    description: |
+      Image registry for the kube-ovn image.
   node-switch-cidr:
     type: string
     default: "100.64.0.0/16"
@@ -41,8 +59,3 @@ options:
     default: "google.com"
     description: |
       External DNS hostname used by kube-ovn-pinger for connectivity testing.
-  image-registry:
-    type: string
-    default: ""
-    description: |
-      Image registry for the kube-ovn image.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ops >= 1.2.0
 Jinja2 < 3.1
+pydantic <=1.9.0 # Python 3.6 support requires <= 1.9.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -44,7 +44,10 @@ PROMETHEUS_RESOURCES = [
 
 
 class SpeakerConfig(BaseModel):
-    name: str = Field(..., regex="^[a-z0-9.-]+$",)
+    name: str = Field(
+        ...,
+        regex="^[a-z0-9.-]+$",
+    )
     node_selector: str = Field(
         ...,
         alias="node-selector",

--- a/src/charm.py
+++ b/src/charm.py
@@ -166,7 +166,11 @@ class KubeOvnCharm(CharmBase):
         kube_ovn_monitor = self.get_resource(
             resources, kind="Deployment", name="kube-ovn-monitor"
         )
-        self.replace_node_selector(kube_ovn_monitor, self.model.config["control-plane-node-label"], "kube-ovn/role")
+        self.replace_node_selector(
+            kube_ovn_monitor,
+            self.model.config["control-plane-node-label"],
+            "kube-ovn/role",
+        )
         self.set_replicas(kube_ovn_monitor, len(node_ips))
 
         self.apply_manifest(resources, "kube-ovn.yaml")
@@ -184,7 +188,9 @@ class KubeOvnCharm(CharmBase):
         ovn_central = self.get_resource(
             resources, kind="Deployment", name="ovn-central"
         )
-        self.replace_node_selector(ovn_central, self.model.config["control-plane-node-label"], "kube-ovn/role")
+        self.replace_node_selector(
+            ovn_central, self.model.config["control-plane-node-label"], "kube-ovn/role"
+        )
         self.set_replicas(ovn_central, len(node_ips))
 
         ovn_central_container = self.get_container_resource(
@@ -216,13 +222,17 @@ class KubeOvnCharm(CharmBase):
         self.add_container_args(
             speaker_container,
             args={
-                 "--announce-cluster-ip": speaker_config_element.get("announce-cluster-ip", False),
-                 "--v": speaker_config_element.get("log-level", 2),
+                "--announce-cluster-ip": speaker_config_element.get(
+                    "announce-cluster-ip", False
+                ),
+                "--v": speaker_config_element.get("log-level", 2),
             },
         )
         self.replace_images(resources, registry)
-        self.replace_node_selector(speaker, speaker_config_element["node-selector"], "ovn.kubernetes.io/bgp")
-        self.replace_name(speaker, speaker_config_element['name'])
+        self.replace_node_selector(
+            speaker, speaker_config_element["node-selector"], "ovn.kubernetes.io/bgp"
+        )
+        self.replace_name(speaker, speaker_config_element["name"])
         self.label_bgp_nodes(speaker_config_element["node-selector"])
         self.apply_manifest(resources, f"{speaker_config_element['name']}.speaker.yaml")
 
@@ -239,7 +249,9 @@ class KubeOvnCharm(CharmBase):
                         try:
                             self.kubectl("delete", "-f", filepath)
                         except CalledProcessError as e:
-                            log.error(f"Error removing speaker daemonset defined in {filepath}: {e}")
+                            log.error(
+                                f"Error removing speaker daemonset defined in {filepath}: {e}"
+                            )
                     try:
                         os.remove(filepath)
                     except FileNotFoundError as e:
@@ -305,7 +317,9 @@ class KubeOvnCharm(CharmBase):
     def apply_speakers(self, registry):
         self.remove_speakers()
         if self.model.config["bgp-speakers"]:
-            speaker_config_list = list(yaml.safe_load(self.model.config["bgp-speakers"]))
+            speaker_config_list = list(
+                yaml.safe_load(self.model.config["bgp-speakers"])
+            )
             for speaker_config in speaker_config_list:
                 self.apply_speaker(registry, speaker_config)
 
@@ -560,15 +574,26 @@ class KubeOvnCharm(CharmBase):
         nodes = json.loads(self.kubectl("get", "nodes", "-o", "json"))["items"]
         for node in nodes:
             if node["metadata"]["labels"].get(label_key) == label_value:
-                log.info(f"Labeling node {node['metadata']['name']} with ovn.kubernetes.io/bgp=true")
-                self.kubectl("label", "nodes", node["metadata"]["name"], "ovn.kubernetes.io/bgp=true")
+                log.info(
+                    f"Labeling node {node['metadata']['name']} with ovn.kubernetes.io/bgp=true"
+                )
+                self.kubectl(
+                    "label",
+                    "nodes",
+                    node["metadata"]["name"],
+                    "ovn.kubernetes.io/bgp=true",
+                )
 
     def unlabel_bgp_nodes(self):
         nodes = json.loads(self.kubectl("get", "nodes", "-o", "json"))["items"]
         for node in nodes:
             if node["metadata"]["labels"].get("ovn.kubernetes.io/bgp"):
-                log.info(f"Removing ovn.kubernetes.io/bgp label from node {node['metadata']['name']}")
-                self.kubectl("label", "nodes", node["metadata"]["name"], "ovn.kubernetes.io/bgp-")
+                log.info(
+                    f"Removing ovn.kubernetes.io/bgp label from node {node['metadata']['name']}"
+                )
+                self.kubectl(
+                    "label", "nodes", node["metadata"]["name"], "ovn.kubernetes.io/bgp-"
+                )
 
     def restart_pods(self):
         self.unit.status = MaintenanceStatus("Restarting pods")
@@ -619,7 +644,9 @@ class KubeOvnCharm(CharmBase):
 
     def wait_for_speakers(self):
         if self.model.config["bgp-speakers"]:
-            speaker_config_list = list(yaml.safe_load(self.model.config["bgp-speakers"]))
+            speaker_config_list = list(
+                yaml.safe_load(self.model.config["bgp-speakers"])
+            )
             for speaker_config in speaker_config_list:
                 speaker_name = speaker_config["name"]
                 self.unit.status = WaitingStatus(f"Waiting for speaker {speaker_name}")

--- a/templates/speaker.yaml
+++ b/templates/speaker.yaml
@@ -1,0 +1,57 @@
+# DO NOT EDIT - For maintainability, we should keep this as close to the
+# upstream manifest as possible.
+#
+# https://raw.githubusercontent.com/kubeovn/kube-ovn/v1.10.4/yamls/speaker.yaml
+# N.B. The 1.10.4 speaker.yaml above lists kube-ovn:v1.10.0" as its image. This has been changed to 1.10.4
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: kube-ovn-speaker
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: kube-ovn-speaker
+  template:
+    metadata:
+      labels:
+        app: kube-ovn-speaker
+        component: network
+        type: infra
+    spec:
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: kube-ovn-speaker
+              topologyKey: kubernetes.io/hostname
+      priorityClassName: system-node-critical
+      serviceAccountName: ovn
+      hostNetwork: true
+      containers:
+        - name: kube-ovn-speaker
+          image: "kubeovn/kube-ovn:v1.10.4"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /kube-ovn/kube-ovn-speaker
+          args:
+            - --neighbor-address=10.32.32.1
+            - --neighbor-as=65030
+            - --cluster-as=65000
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: 500m
+              memory: 300Mi
+      nodeSelector:
+        kubernetes.io/os: "linux"
+        ovn.kubernetes.io/bgp: "true"

--- a/tests/data/nginx.yaml
+++ b/tests/data/nginx.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: rocks.canonical.com/cdk/nginx:1.18
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  annotations:
+    ovn.kubernetes.io/bgp: "true"
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    app: nginx

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -345,8 +345,8 @@ async def grafana_app(ops_test, k8s_model):
         log.info("Deploying grafana-k8s ...")
         await m.deploy(entity_url="grafana-k8s", trust=True, channel="edge")
 
-        await m.block_until(lambda: "grafana-k8s" in m.applications, timeout=60)
-        await m.wait_for_idle(status="active")
+        await m.block_until(lambda: "grafana-k8s" in m.applications, timeout=60 * 5)
+        await m.wait_for_idle(status="active", timeout=60 * 5)
 
     yield "grafana-k8s"
 
@@ -469,11 +469,11 @@ async def prometheus_app(ops_test, k8s_model):
         log.info("Deploying prometheus-k8s ...")
         await m.deploy(entity_url="prometheus-k8s", trust=True, channel="edge")
 
-        await m.block_until(lambda: "prometheus-k8s" in m.applications, timeout=60 * 3)
+        await m.block_until(lambda: "prometheus-k8s" in m.applications, timeout=60 * 5)
         await m.wait_for_idle(
             apps=["prometheus-k8s"],
             status="active",
-            timeout=60 * 3,
+            timeout=60 * 5,
             raise_on_error=False,
         )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -578,6 +578,7 @@ async def expected_prometheus_metrics():
 
     return metrics
 
+
 @pytest_asyncio.fixture(scope="module")
 async def nginx(client):
     log.info("Creating Nginx deployment and service ...")
@@ -596,6 +597,7 @@ async def nginx(client):
         for obj in codecs.load_all_yaml(f):
             client.delete(type(obj), obj.metadata.name)
 
+
 @pytest_asyncio.fixture(scope="module")
 async def nginx_cluster_ip(client, nginx):
     log.info("Getting Nginx service IP ...")
@@ -608,6 +610,7 @@ async def nginx_pods(client, nginx):
     def f():
         pods = client.list(Pod, namespace="default", labels={"app": "nginx"})
         return pods
+
     return f
 
 
@@ -616,49 +619,67 @@ def default_subnet(client, subnet_resource):
     def f():
         subnet = client.get(subnet_resource, name="ovn-default")
         return subnet
+
     return f
 
 
 @pytest_asyncio.fixture(scope="module")
-async def bird(ops_test, client):
-    await ops_test.model.deploy(entity_url="bird", channel="stable", num_units=1)
+async def bird(ops_test):
+    await ops_test.model.deploy(entity_url="bird", channel="stable", num_units=3)
     await ops_test.model.block_until(
-        lambda: "bird" in ops_test.model.applications,
-        timeout=60
+        lambda: "bird" in ops_test.model.applications, timeout=60
     )
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
     log.info("Bird deployment complete")
 
-    bird_app = ops_test.model.applications['bird']
-    kube_ovn_app = ops_test.model.applications['kube-ovn']
-    worker_app = ops_test.model.applications['kubernetes-worker']
-    # configure kube-ovn to peer with bird
-    await kube_ovn_app.set_config({
-        'bgp-speakers': yaml.dump([
-            {'name': f'test-speaker-{unit.name.replace("/", "-")}',
-             'node-selector': "juju-application=kubernetes-worker",
-             'neighbor-address': unit.public_address, 'neighbor-as': 64512, 'cluster-as': 64512,
-             'announce-cluster-ip': True, 'v': 5}
-            for unit in bird_app.units
-        ])
-    })
+    bird_app = ops_test.model.applications["bird"]
+    kube_ovn_app = ops_test.model.applications["kube-ovn"]
+    worker_app = ops_test.model.applications["kubernetes-worker"]
+
+    log.info("Configuring Kube-OVN to peer with Bird")
+    await kube_ovn_app.set_config(
+        {
+            "bgp-speakers": yaml.dump(
+                [
+                    {
+                        "name": f'test-speaker-{bird_unit.name.replace("/", "-")}',
+                        "node-selector": f"kubernetes.io/hostname={worker_unit.machine.hostname}",
+                        "neighbor-address": bird_unit.public_address,
+                        "neighbor-as": 64512,
+                        "cluster-as": 64512,
+                        "announce-cluster-ip": True,
+                        "log-level": 5,
+                    }
+                    for (bird_unit, worker_unit) in zip(
+                        bird_app.units, worker_app.units
+                    )
+                ]
+            )
+        }
+    )
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
 
-    # configure bird to peer with kube-ovn
-    await bird_app.set_config({
-        'bgp-peers': yaml.dump([
-            {'address': unit.public_address, 'as-number': 64512}
-            for unit in worker_app.units
-        ])
-    })
+    log.info("Configuring Bird to peer with Kube-OVN")
+    await bird_app.set_config(
+        {
+            "bgp-peers": yaml.dump(
+                [
+                    {"address": unit.public_address, "as-number": 64512}
+                    for unit in worker_app.units
+                ]
+            )
+        }
+    )
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
 
     yield
 
     log.info("Setting empty bgp-speakers config ...")
-    await kube_ovn_app.set_config({
-        'bgp-speakers': '',
-    })
+    await kube_ovn_app.set_config(
+        {
+            "bgp-speakers": "",
+        }
+    )
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
 
     cmd = "remove-application bird --force"
@@ -666,7 +687,9 @@ async def bird(ops_test, client):
     log.info(stdout)
     log.info(stderr)
     assert rc == 0
-    await ops_test.model.block_until(lambda: "bird" not in ops_test.model.applications, timeout=60 * 10)
+    await ops_test.model.block_until(
+        lambda: "bird" not in ops_test.model.applications, timeout=60 * 10
+    )
 
 
 @pytest.fixture()
@@ -684,23 +707,29 @@ def annotated_nginx_pods(nginx_pods, annotate, default_subnet, client):
 async def annotated_subnet_nginx_pods(nginx_pods, default_subnet, client, kubectl):
     # For some reason lightkube is having trouble annotating the custom subnet resource, so using kubectl instead
     # Lightkube doesn't fail, it just doesn't seem to apply the annotation
-    shcmd = 'annotate subnet ovn-default ovn.kubernetes.io/bgp=true --overwrite=true'
+    shcmd = "annotate subnet ovn-default ovn.kubernetes.io/bgp=true --overwrite=true"
     log.info("Annotating default subnet with ovn.kubernetes.io/bgp=true ...")
     await kubectl(*shlex.split(shcmd))
     yield nginx_pods()
 
     log.info("Removing ovn.kubernetes.io/bgp annotation from default subnet ...")
-    shcmd = 'annotate subnet ovn-default ovn.kubernetes.io/bgp- --overwrite=true'
+    shcmd = "annotate subnet ovn-default ovn.kubernetes.io/bgp- --overwrite=true"
     await kubectl(*shlex.split(shcmd))
 
 
 @pytest.fixture(scope="module")
 def annotate(client, ops_test):
     def f(obj, annotation_dict, patch_type=PatchType.STRATEGIC):
-        log.info(f"Annotating {type(obj)} {obj.metadata.name} with {annotation_dict} ...")
+        log.info(
+            f"Annotating {type(obj)} {obj.metadata.name} with {annotation_dict} ..."
+        )
         obj.metadata.annotations = annotation_dict
         client.patch(
-            type(obj), obj.metadata.name, obj, namespace=obj.metadata.namespace, patch_type=patch_type
+            type(obj),
+            obj.metadata.name,
+            obj,
+            namespace=obj.metadata.namespace,
+            patch_type=patch_type,
         )
-    return f
 
+    return f

--- a/tests/integration/test_kube_ovn.py
+++ b/tests/integration/test_kube_ovn.py
@@ -151,7 +151,7 @@ async def test_pod_netem_latency(kubectl_exec, client, iperf3_pods, annotate):
     # ping once before the test, as the first ping delay takes a bit,
     # but subsequent pings work as expected
     # https://wiki.linuxfoundation.org/networking/netem#how_come_first_ping_takes_longer
-    stdout = await ping(kubectl_exec, pinger, pingee, namespace)
+    await ping(kubectl_exec, pinger, pingee, namespace)
 
     # latency is in ms
     expected_latency = 1000

--- a/tests/integration/test_kube_ovn.py
+++ b/tests/integration/test_kube_ovn.py
@@ -143,7 +143,7 @@ async def test_pod_netem_latency(kubectl_exec, client, iperf3_pods, annotate):
         before=before_log(log, logging.INFO),
     )
     async def ping_for_latency(latency):
-        log.info("Testing ping latency ...")
+        log.info(f"Testing that ping latency == {latency} ...")
         stdout = await ping(kubectl_exec, pinger, pingee, namespace)
         average_latency = avg_ping_delay(stdout)
         assert isclose(average_latency, latency, rel_tol=0.05)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,6 +9,10 @@ def pytest_configure(config):
         "markers",
         "skip_kubectl_mock: mark tests which do not mock out KubeOvnCharm.kubectl",
     )
+    config.addinivalue_line(
+        "markers",
+        "skip_unlabel_bgp_nodes_mock: mark tests which do not mock out KubeOvnCharm.unlabel_bgp_nodes",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -18,4 +22,13 @@ def kubectl(request):
         yield KubeOvnCharm.kubectl
         return
     with mock.patch("charm.KubeOvnCharm.kubectl", autospec=True) as mocked:
+        yield mocked
+
+@pytest.fixture(autouse=True)
+def unlabel_bgp_nodes(request):
+    """Mock out unlabel_bgp_nodes."""
+    if "skip_unlabel_bgp_nodes_mock" in request.keywords:
+        yield KubeOvnCharm.unlabel_bgp_nodes
+        return
+    with mock.patch("charm.KubeOvnCharm.unlabel_bgp_nodes", autospec=True) as mocked:
         yield mocked

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -23,13 +23,3 @@ def kubectl(request):
         return
     with mock.patch("charm.KubeOvnCharm.kubectl", autospec=True) as mocked:
         yield mocked
-
-
-@pytest.fixture(autouse=True)
-def unlabel_bgp_nodes(request):
-    """Mock out unlabel_bgp_nodes."""
-    if "skip_unlabel_bgp_nodes_mock" in request.keywords:
-        yield KubeOvnCharm.unlabel_bgp_nodes
-        return
-    with mock.patch("charm.KubeOvnCharm.unlabel_bgp_nodes", autospec=True) as mocked:
-        yield mocked

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -24,6 +24,7 @@ def kubectl(request):
     with mock.patch("charm.KubeOvnCharm.kubectl", autospec=True) as mocked:
         yield mocked
 
+
 @pytest.fixture(autouse=True)
 def unlabel_bgp_nodes(request):
     """Mock out unlabel_bgp_nodes."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1025,7 +1025,7 @@ def test_apply_speaker(
         "log-level": 5,
     }
 
-    parsed_speaker_config_dict = SpeakerConfig(**speaker_dict).dict(by_alias=True)
+    parsed_speaker_config = SpeakerConfig(**speaker_dict)
     (kube_ovn_speaker,) = get_resource.side_effect = [
         mock.MagicMock(),
     ]
@@ -1035,7 +1035,7 @@ def test_apply_speaker(
     ]
 
     # Test Method
-    charm.apply_speaker(DEFAULT_IMAGE_REGISTRY, parsed_speaker_config_dict)
+    charm.apply_speaker(DEFAULT_IMAGE_REGISTRY, parsed_speaker_config)
 
     # Assert Correct Behavior
     assert charm.unit.status == MaintenanceStatus("Applying Speaker resource")
@@ -1091,8 +1091,8 @@ def test_apply_speaker(
         "cluster-as": 65000,
     }
 
-    parsed_speaker_config_dict = SpeakerConfig(**speaker_dict).dict(by_alias=True)
-    charm.apply_speaker(DEFAULT_IMAGE_REGISTRY, parsed_speaker_config_dict)
+    parsed_speaker_config = SpeakerConfig(**speaker_dict)
+    charm.apply_speaker(DEFAULT_IMAGE_REGISTRY, parsed_speaker_config)
     add_container_args.assert_called_once_with(
         kube_ovn_speaker_container,
         args={
@@ -1166,17 +1166,17 @@ def test_apply_speakers(remove_speakers, apply_speaker, harness, charm, caplog):
     harness.update_config(config_dict)
     charm.apply_speakers(DEFAULT_IMAGE_REGISTRY)
     remove_speakers.assert_called_once()
-    apply_speaker.assert_called_once_with(
+    apply_speaker(
         DEFAULT_IMAGE_REGISTRY,
-        {
-            "name": "my-speaker",
-            "node-selector": "juju-application=kubernetes-worker",
-            "neighbor-address": IPv4Address("10.32.32.1"),
-            "neighbor-as": 65030,
-            "cluster-as": 65000,
-            "announce-cluster-ip": True,
-            "log-level": 5,
-        },
+        SpeakerConfig.construct(
+            name="my-speaker",
+            node_selector="juju-application=kubernetes-worker",
+            neighbor_address=IPv4Address("10.32.32.1"),
+            neighbor_as=65030,
+            cluster_as=65000,
+            announce_cluster_ip=True,
+            log_level=5,
+        ),
     )
 
     # Try with empty config option

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -225,7 +225,7 @@ def test_is_kubeconfig_available(harness, charm):
     assert not charm.is_kubeconfig_available()
 
     harness.update_relation_data(
-        rel_id, "kubernetes-control-plane/0", {"kubeconfig-hash": 1234}
+        rel_id, "kubernetes-control-plane/0", {"kubeconfig-hash": "1234"}
     )
     assert charm.is_kubeconfig_available()
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     urllib3
     pytest
     pytest-asyncio
-    pytest-operator
+    pytest-operator==1.0.0b1
     lightkube
     tenacity
 commands = pytest --asyncio-mode=auto --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {[vars]tst_path}integration

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     urllib3
     pytest
     pytest-asyncio
-    pytest-operator==1.0.0b1
+    pytest-operator
     lightkube
     tenacity
 commands = pytest --asyncio-mode=auto --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {[vars]tst_path}integration


### PR DESCRIPTION
This PR adds BGP support to the kube-ovn charm. 

Using BGP amounts to deploying one or more speaker daemonsets (if running multiple speaker daemonsets, the nodes hosting the daemonsets must not overlap) that run the speaker application. Arguments (exposed in charm config) passed to the speaker application control how it peers with routers (such as bird). Nodes hosting the daemonset are annotated by the charm to mark them as BGP enabled.

The user controls what they want to expose via special BGP annotations (performed by the user using kubectl). The annotations allow for fine grain control over what gets exposed. If a subnet is annotated, all pods bound to that subnet would be exposed. Individual pods can also be exposed, as well as ClusterIP services (see the `announce-cluster-ip` mentioned below for more details on how services can be exposed). 

The speaker then watches for subnets, pods, and services that have the BGP annotation, and sends the IP information of those annotated objects to the peered router. These IPs are then accessible from outside the cluster via the router. 

Various methods were added to accomplish deploying the speaker daemonset injected with configurable values using charm config, and corresponding unit tests were added for those. 

Integration tests were added that deploy multiple units of the bird charm, and peer kube-ovn with those bird units (with each bird unit getting a corresponding daemonset). The tests then test that a subnet, pods, and a service are reachable from each unit.

Documentation regarding BGP support in Kube-OVN is [here](https://kubeovn.github.io/docs/v1.10.x/en/advance/with-bgp/). Note that 2 additional fields were added to the config option in addition to the ones specified in the spec document. `announce-cluster-ip` must be set to True if the user wants services to be exposed as only pods and subnets are gathered by the speaker by default. The `log-level` field is used to set the verbosity of the speaker logs. With a high log level (5+), it willl periodically log each IP it is sending to the peered router, which is helpful for debugging. The default log level only logs basic information like when the application starts, and when a peer connection is made. 