### PR TITLE
Scp/external gateway testing

### DIFF
--- a/.github/workflows/vsphere-integration.yml
+++ b/.github/workflows/vsphere-integration.yml
@@ -8,9 +8,9 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Setup operator environment
@@ -34,7 +34,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-run-artifacts
           path: tmp

--- a/tests/data/external-gateway.yaml
+++ b/tests/data/external-gateway.yaml
@@ -1,4 +1,5 @@
 # https://kubeovn.github.io/docs/v1.10.x/en/advance/external-gateway/
+# N.B. Gateway type must be distributed, not centralized as shown in the documentation
 kind: Subnet
 apiVersion: kubeovn.io/v1
 metadata:

--- a/tests/data/external-gateway.yaml
+++ b/tests/data/external-gateway.yaml
@@ -1,0 +1,33 @@
+# https://kubeovn.github.io/docs/v1.10.x/en/advance/external-gateway/
+kind: Subnet
+apiVersion: kubeovn.io/v1
+metadata:
+  name: external
+  annotations:
+    ovn.kubernetes.io/bgp: "true"
+spec:
+  cidrBlock: 172.31.0.0/16
+  gatewayType: distributed
+  natOutgoing: false
+  externalEgressGateway: 192.168.0.1
+  policyRoutingTableID: 1000
+  policyRoutingPriority: 1500
+  namespaces:
+  - external-ns
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-ns
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: perf-client
+  namespace: external-ns
+  labels:
+    app.kubernetes.io/name: perf-client
+spec:
+  containers:
+  - name: perf-client
+    image: rocks.canonical.com/cdk/kubeovn/perf:latest

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -803,7 +803,9 @@ async def external_gateway_pod(ops_test, client, subnet_resource):
     log.info(f"Getting IP for bird unit {bird_unit.name}")
     cmd = f"juju show-unit {bird_unit.name}"
     rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
-    assert rc == 0, f"Failed to get {bird_unit.name} unit data: {(stdout or stderr).strip()}"
+    assert (
+        rc == 0
+    ), f"Failed to get {bird_unit.name} unit data: {(stdout or stderr).strip()}"
 
     unit_data = yaml.safe_load(stdout)
     bird_unit_ip = unit_data[bird_unit.name]["public-address"]
@@ -833,7 +835,6 @@ async def external_gateway_pod(ops_test, client, subnet_resource):
     log.info("Deleting external-gateway related resources ...")
     for obj in codecs.load_all_yaml(path.read_text()):
         client.delete(type(obj), obj.metadata.name, namespace=obj.metadata.namespace)
-
 
 
 @pytest_asyncio.fixture(params=["pods", "subnet", "service"])

--- a/tests/integration/test_kube_ovn.py
+++ b/tests/integration/test_kube_ovn.py
@@ -41,7 +41,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     plugin_path = Path.cwd() / "plugins/kubectl-ko"
 
     overlays = [
-        ops_test.Bundle("kubernetes-core", channel="edge"),
+        ops_test.Bundle("kubernetes-core", channel="1.25/stable"),
         Path("tests/data/charm.yaml"),
         Path("tests/data/vsphere-overlay.yaml"),
     ]

--- a/tests/integration/test_kube_ovn.py
+++ b/tests/integration/test_kube_ovn.py
@@ -10,6 +10,7 @@ import logging
 import json
 import re
 from contextlib import suppress
+import time
 
 from ipaddress import ip_address, ip_network
 from lightkube.types import PatchType
@@ -21,6 +22,8 @@ from tenacity import (
     stop_after_delay,
     wait_fixed,
     before_log,
+    AsyncRetrying,
+    RetryError
 )
 
 
@@ -612,6 +615,42 @@ async def test_network_policies(ops_test, client, kubectl_exec, network_policies
                 type(obj), obj.metadata.name, namespace=obj.metadata.namespace
             )
 
+
+class ExternalPingError(Exception):
+    pass
+
+
+@retry(
+    retry=retry_if_exception_type(ExternalPingError),
+    stop=stop_after_delay(60 * 10),
+    wait=wait_fixed(1),
+    before=before_log(log, logging.INFO),
+)
+async def run_external_ping_test(kubectl_exec, external_gateway_pod, bird_container_ip):
+    ping_cmd = f"ping -w 5 {bird_container_ip}"
+    args = external_gateway_pod.metadata.name, external_gateway_pod.metadata.namespace, ping_cmd
+    rc, stdout, stderr = await kubectl_exec(*args, check=False)
+    if rc == 0:
+        return True
+    else:
+        raise ExternalPingError(f"Failed to ping {bird_container_ip} from pod {external_gateway_pod.metadata.name}")
+
+
+async def test_external_gateway(bird_container_ip, external_gateway_pod, kubectl_exec):
+    # This tests that a pod in a subnet configured with an external gateway can reach
+    # an LXD container running on a BIRD unit
+    # The subnet has the IP of the bird unit configured as the external gateway IP
+    # A perf pod is deployed in the subnet, and the pod pings the IP of the LXD container directly.
+    # KubeOVN has no knowledge of this LXD container IP (via BGP or otherwise)
+    # KubeOVN sees that the IP trying to be reached is external to its subnet, so sends the traffic to the configured
+    # gateway (the bird unit)
+    # Bird unit receives the traffic, and then routes it to the LXD container via the bridge network
+    # Response traffic from the LXD container is then routed back to the pod via BGP (this is necessary as the subnet
+    # has natOutgoing set to false, so BGP is what enables response traffic to get back to the pod)
+
+    log.info(f"Pinging {bird_container_ip} from within pod {external_gateway_pod.metadata.name} in namespace "
+             f"{external_gateway_pod.metadata.namespace}")
+    assert await run_external_ping_test(kubectl_exec, external_gateway_pod, bird_container_ip)
 
 class iPerfError(Exception):
     pass

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
 
 [testenv:integration]
 deps =
-    git+https://github.com/charmed-kubernetes/python-libjuju.git@2.9.11+ck1
+    juju
     aiohttp
     urllib3
     pytest


### PR DESCRIPTION
This PR adds a test for external gateway behavior. The test requires quite a bit of setup which I will explain below:

The premise of the test is that a subnet can be configured with an external gateway. If KubeOVN detects traffic coming from pods in this subnet that is external to it (ie pods reaching out to IPs not belonging to that subnet CIDR), it will send that traffic to the configured externalEgressGateway as shown [here](https://kubeovn.github.io/docs/v1.10.x/en/advance/external-gateway/). 

To test this behavior requires that return traffic be able to get back to the pod initiating requests. Since natOutgoing must be set to false as part of the subnet configuration, BGP is used to facilitate return traffic back to the pod. The bird fixture used initially for the BGP testing is reused for this gateway test.

With BGP enabled, KubeOVN is able to route traffic to/from the bird unit. Because of this, simply pinging the bird unit is not sufficient to test the gateway behavior, and we need some other external IP unknown to kubeOVN to ping. An LXD ubuntu container running on the bird unit is used for this. The bird unit can route traffic to it via the LXD bridge/ip forwarding, and kubeOVN knows nothing of the IP. It simply sees that a pod is trying to reach some external IP, so sends the traffic to the bird unit acting as the gateway. The response of the ping can be routed back to the initiating pod via BGP. 

2 fixtures were added. The bird_container_ip relies on the BGP related bird setup mentioned prior. It then enables IP forwarding, and creates the ubuntu container, eventually returning the IP of the container.

The external_gateway_pod fixture creates the special subnet, a corresponding namespace, and a perf pod in that namespace.

The test simply pings the LXD container IP from the perf pod. Since it can take some time for the subnet CIDR to be propogated via BGP peering, a retry mechanism is used to repeatedly try the ping. 
