### PR TITLE
Pin setuptools used for noble and jammy

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -109,7 +109,6 @@ parts:
   charm:
     plugin: charm
     source: .
-    charm-python-packages: [setuptools]
 bases:
   - build-on:
     - name: "ubuntu"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ops >= 1.2.0
 Jinja2 < 3.1
 pydantic <=1.9.0 # Python 3.6 support requires <= 1.9.0
+setuptools == 79.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ops >= 1.2.0
 Jinja2 < 3.1
-pydantic <=1.9.0 # Python 3.6 support requires <= 1.9.0
+pydantic < 2
 setuptools == 79.0.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,6 @@ import yaml
 from jinja2 import Environment, FileSystemLoader
 
 import ops
-import ops.model
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
 
@@ -17,12 +16,7 @@ from charms.prometheus_k8s.v0.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
 )
 
-from pydantic import (
-    BaseModel,
-    IPvAnyAddress,
-    ValidationError,
-    Field,
-)
+from pydantic import BaseModel, IPvAnyAddress, ValidationError, Field, constr
 
 log = logging.getLogger(__name__)
 
@@ -37,20 +31,19 @@ PROMETHEUS_RESOURCES = [
 
 
 class SpeakerConfig(BaseModel):
-    name: str = Field(
-        ...,
-        regex="^[a-z0-9.-]+$",
-    )
-    node_selector: str = Field(
+    name: constr(regex=r"^[a-z0-9.-]+$") = Field(...)
+    node_selector: constr(regex=r"^[\w./-]+=[\w.-]+$") = Field(
         ...,
         alias="node-selector",
-        regex=r"^[\w./-]+=[\w.-]+$",
     )
     neighbor_address: IPvAnyAddress = Field(..., alias="neighbor-address")
     neighbor_as: int = Field(..., alias="neighbor-as", gt=0, lt=65536)
     cluster_as: int = Field(..., alias="cluster-as", gt=0, lt=65536)
     announce_cluster_ip: bool = Field(False, alias="announce-cluster-ip")
     log_level: int = Field(2, alias="log-level", gt=-1)
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class KubeOvnCharm(ops.CharmBase):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1179,13 +1179,7 @@ def test_apply_speaker(
             ["neighbor-address\n  value is not a valid IPv4 or IPv6 address"],
         ),
         (
-            {
-                "name": None,
-                "node-selector": None,
-                "neighbor-address": None,
-                "neighbor-as": None,
-                "cluster-as": None,
-            },
+            {},
             [
                 "name\n  field required",
                 "node-selector\n  field required",
@@ -1216,18 +1210,8 @@ def test_apply_speaker(
     ],
 )
 def test_speaker_config_validation(test_input, expected_msgs):
-    base = {
-        "name": "my-speaker",
-        "node-selector": "juju-application=kubernetes-worker",
-        "neighbor-address": "192.168.0.1",
-        "neighbor-as": 65030,
-        "cluster-as": 65000,
-        **test_input,
-    }
-    base = {k: v for k, v in base.items() if v is not None}
-
     with pytest.raises(ValidationError) as excinfo:
-        SpeakerConfig(**base)
+        SpeakerConfig(**test_input)
     for msg in expected_msgs:
         assert msg in str(excinfo.value)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1179,7 +1179,13 @@ def test_apply_speaker(
             ["neighbor-address\n  value is not a valid IPv4 or IPv6 address"],
         ),
         (
-            {},
+            {
+                "name": None,
+                "node-selector": None,
+                "neighbor-address": None,
+                "neighbor-as": None,
+                "cluster-as": None,
+            },
             [
                 "name\n  field required",
                 "node-selector\n  field required",
@@ -1197,10 +1203,31 @@ def test_apply_speaker(
             ["log-level\n  ensure this value is greater than -1"],
         ),
     ],
+    ids=[
+        "empty_name",
+        "neighbor_as_zero",
+        "cluster_as_zero",
+        "neighbor_as_too_high",
+        "cluster_as_too_high",
+        "invalid_neighbor_address",
+        "missing_fields",
+        "invalid_node_selector",
+        "log_level_too_low",
+    ],
 )
 def test_speaker_config_validation(test_input, expected_msgs):
+    base = {
+        "name": "my-speaker",
+        "node-selector": "juju-application=kubernetes-worker",
+        "neighbor-address": "192.168.0.1",
+        "neighbor-as": 65030,
+        "cluster-as": 65000,
+        **test_input,
+    }
+    base = {k: v for k, v in base.items() if v is not None}
+
     with pytest.raises(ValidationError) as excinfo:
-        SpeakerConfig(**test_input)
+        SpeakerConfig(**base)
     for msg in expected_msgs:
         assert msg in str(excinfo.value)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 88
 # ignore E501: let black handle line lengths, sometimes it will go over 88
-extend-ignore = E501
+extend-ignore = E501,F722
 
 [tox]
 skipsdist = True
@@ -37,7 +37,7 @@ deps =
     pytest
     pytest-cov
     -r{toxinidir}/requirements.txt
-commands = 
+commands =
     pytest \
         --cov={[vars]src_path} \
         --cov-report=term-missing \
@@ -57,7 +57,7 @@ deps =
     pytest-operator
     lightkube
     tenacity
-commands = 
+commands =
     pytest \
         --show-capture=no \
         --log-cli-level=INFO \


### PR DESCRIPTION
* pins setuptools used by python 3.10 and 3.12 
* overrides charmcraft 2.x's default of `setuptools-59.6.0`

Similar to:
* https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/385
* https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/191
* https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/40
* https://github.com/charmed-kubernetes/charm-calico/pull/119
* https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer/pull/46