### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/naming-lint-unit.yml
+++ b/.github/workflows/naming-lint-unit.yml
@@ -4,13 +4,13 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@7aa0f7a606f182bd03a7adb28e0d710216101ca5 # main
     with:
       fail-on-error: "true"
 
   lint-unit:
     name: Lint Unit
-    uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@6ee58c37d404effad4598ce7b523dbaf0cb99285 # main
     with:
       with-uv: true
       python: "['3.10', '3.12']"

--- a/.github/workflows/vsphere-integration.yml
+++ b/.github/workflows/vsphere-integration.yml
@@ -8,16 +8,16 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Read charmcraft version file
         id: charmcraft
         run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
+        uses: charmed-kubernetes/actions-operator@ea90ed489690bf3b1c1fcca6ac5f9edab70aecb0 # main
         with:
           provider: vsphere
           juju-channel: 3/stable
@@ -40,7 +40,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-run-artifacts
           path: tmp


### PR DESCRIPTION
Pin all GitHub Actions to their commit SHAs to improve supply chain security.

This prevents:
- Compromised tags from injecting malicious code
- Unexpected behavior from mutable references
- Supply chain attacks via action tag manipulation