### PR TITLE
fix: add nosec annotations for bandit HIGH findings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -53,7 +53,7 @@ class KubeOvnCharm(ops.CharmBase):
         super().__init__(*args)
         self.grafana_dashboard_provider = GrafanaDashboardProvider(self)
         self.remote_write_consumer = PrometheusRemoteWriteConsumer(self)
-        self.jinja2_environment = Environment(loader=FileSystemLoader("templates/"))
+        self.jinja2_environment = Environment(loader=FileSystemLoader("templates/")) # nosec B701
         self.stored.set_default(kube_ovn_configured=False)
         self.stored.set_default(pod_restart_needed=False)
         self.stored.set_default(grafana_agent_configured=False)


### PR DESCRIPTION
## Summary

Add inline `# nosec` annotations for intentional security patterns flagged by the new bandit SAST workflow (`-lll`, HIGH severity only).

These are all documented exceptions — not actual security vulnerabilities:

| Finding | Annotation | Rationale |
|---------|-----------|-----------|
| B103 | `# nosec B103` | chmod 0o777 in upstream library code |
| B202 | `# nosec B202` | `tarfile.extractall` from trusted upstream release artifacts |
| B324 | `# nosec B324` | MD5 used for content hashing, not security |
| B501 | `# nosec B501` | `verify=False` used for internal cluster communication |
| B602 | `# nosec B602` | `subprocess(shell=True)` with trusted/controlled input |
| B701 | `# nosec B701` | Jinja2 autoescape disabled for non-HTML template generation |

## Context
Companion to the SAST workflows PR. Once both are merged, the bandit workflow will pass cleanly.